### PR TITLE
Feature/log errors to stdout

### DIFF
--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -1,6 +1,12 @@
 monolog:
     channels:
         - deprecation # Deprecations are logged in the dedicated "deprecation" channel when it exists
+    handlers:
+        nested:
+            type: stream
+            path: php://stderr
+            level: error
+            formatter: monolog.formatter.json
 
 when@dev:
     monolog:


### PR DESCRIPTION
Zorgt dat meldingen van PHP van error of hoger naar de STDOUT gestuurd worden.
Hierdoor zijn deze ook via de Log Analytics workspace binnen de Azure Portal zichtbaar 