### PR TITLE
113571 - File extension not always guessed

### DIFF
--- a/src/EventListener/DocumentUploadSubscriber.php
+++ b/src/EventListener/DocumentUploadSubscriber.php
@@ -56,7 +56,10 @@ class DocumentUploadSubscriber implements EventSubscriber
         $flysystem = $this->fileStorageSelector->getByGroep($object->getGroep());
         /** @var $uploadedFile UploadedFile */
         $uploadedFile = $object->getFile();
-        $filename = time() . '-' . $object->getMd5Hash() . '-' . uniqid(null, true) . '.' . $uploadedFile->guessExtension();
+        $filename = time() . '-' . $object->getMd5Hash() . '-' . uniqid(null, true) . '.';
+
+        //making sure the filename has an extension.
+        $filename .= $uploadedFile->guessExtension() ?? $uploadedFile->getClientOriginalExtension();
 
         $object->setOrigineleBestandsnaam($uploadedFile->getClientOriginalName());
         $object->setOrigineleExtensie($uploadedFile->getClientOriginalExtension());


### PR DESCRIPTION
When going through the logs i saw that the system does not always knows what extension as file is, which can cause the files to be saved without one and the filename ending with a dot.

This PR solves that by checking if it can guess it and else add the extension of the original uploaded file